### PR TITLE
feat: fetch versions of external components

### DIFF
--- a/src/controllers/serverVersions.ts
+++ b/src/controllers/serverVersions.ts
@@ -23,6 +23,13 @@ function compileVersions(component: any, prefix = ''): Versions {
 			Object.keys(compiledVersions).forEach((key) => (versions[key] = compiledVersions[key]))
 		})
 	}
+	if (component._extVersions) {
+		component._extVersions.forEach((child: PromiseSettledResult<any>) => {
+			if (child.status === 'rejected' || child.value.error) return
+			const compiledVersions = compileVersions(child.value, '~' + child.value.name + '.')
+			Object.keys(compiledVersions).forEach((key) => (versions[key] = compiledVersions[key]))
+		})
+	}
 	return versions
 }
 

--- a/test/serverStatus.test.ts
+++ b/test/serverStatus.test.ts
@@ -31,8 +31,11 @@ describe('GET /serverStatus', () => {
 		expect(dom.window.document.characterSet).toEqual('UTF-8')
 		dom.window.document.getElementById('versions')
 
-		expect(fetch).toHaveBeenCalledTimes(1)
-		expect(fetch).toHaveBeenCalledWith('http://localhost:3000/health', {
+		expect(fetch).toHaveBeenCalledTimes(2)
+		expect(fetch).toHaveBeenNthCalledWith(1, 'http://localhost:3000/health', {
+			method: 'GET',
+		})
+		expect(fetch).toHaveBeenNthCalledWith(2, 'http://localhost:3000/external/sisyfos/health', {
 			method: 'GET',
 		})
 	})

--- a/test/serverVersions.test.ts
+++ b/test/serverVersions.test.ts
@@ -32,8 +32,11 @@ describe('GET /serverVersions', () => {
 		expect(dom.window.document.characterSet).toEqual('UTF-8')
 		dom.window.document.getElementById('versions')
 
-		expect(fetch).toHaveBeenCalledTimes(1)
-		expect(fetch).toHaveBeenCalledWith('http://localhost:3000/health', {
+		expect(fetch).toHaveBeenCalledTimes(2)
+		expect(fetch).toHaveBeenNthCalledWith(1, 'http://localhost:3000/health', {
+			method: 'GET',
+		})
+		expect(fetch).toHaveBeenNthCalledWith(2, 'http://localhost:3000/external/sisyfos/health', {
 			method: 'GET',
 		})
 	})


### PR DESCRIPTION
This PR adds the option to fetch versions of external components that are not exposed through the Sofie `/health` endpoint.

Mostly to be used with Sisyfos, but it should be trivial to add other components as long as they are exposed on the same hostname (i.e. through nginx url rewriting)